### PR TITLE
tooltip追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -125,7 +125,32 @@
    left: 50%;
    transform: translateX(-50%);
  }
- 
+ .GameFriend_box i[header-data-tooltip]{
+  cursor: pointer;
+ }
+
+ .GameFriend_box i[header-data-tooltip]::after{
+  content: attr(header-data-tooltip);
+  position: absolute;
+  left: 100%;
+  top: 50%; 
+  transform: translateY(-50%);
+  background-color: rgb(255, 255, 255);
+  color: rgb(37, 37, 37);
+  padding: 5px 10px;
+  border-radius: 4px;
+  white-space: nowrap;
+  font-size: 13px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease-in-out;
+  margin-left: 5px; 
+ }
+ .GameFriend_box i[header-data-tooltip]:hover::after {
+  opacity: 1;
+  visibility: visible;
+}
+
  .login_box {
   position: absolute;
   top: 50%;
@@ -2153,3 +2178,42 @@ button:disabled {
   padding-bottom: 1px;
 }
 
+
+.tooltip-wrapper {
+  font-size: 24px;
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.tooltip-wrapper i[data-tooltip] {
+  top: 8px;
+  left: -11px;
+  font-size: 22px;
+  color: #000000c0;
+  position: relative;
+  cursor: pointer;
+}
+
+.tooltip-wrapper i[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 100%;
+  top: 50%; 
+  transform: translateY(-50%);
+  background-color: rgb(233, 232, 232);
+  color: rgb(99, 99, 99);
+  padding: 5px 10px;
+  border-radius: 4px;
+  white-space: nowrap;
+  font-size: 12px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease-in-out;
+  margin-left: 5px; 
+}
+
+.tooltip-wrapper i[data-tooltip]:hover::after {
+  opacity: 1;
+  visibility: visible;
+}

--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -94,7 +94,12 @@
     <label for="audio-select">Select Audio Device:</label>
     <select class = "audio-select" id="audio-select"></select>
   </div>
-  <button id="startButton">カメラとマイクを許可</button>
+  <div class = "video-audio-permit">
+    <button id="startButton">カメラとマイクを許可</button>
+    <div class="tooltip-wrapper">
+      <i class="bi bi-question-circle" data-tooltip="ブラウザの許可をしてもデバイスが表示されない場合は、ページを再読み込みしてください"></i>
+    </div>
+  </div>
   <hr />
   
   <button id="join-button">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,7 +19,7 @@
   </div>
   <div class="GameFriend_box">
     <%= link_to "GameFriend", "/", class: "GameFriend" %>
-    <i id="openModal", class="bi bi-question-circle"></i>
+    <i id="openModal", class="bi bi-question-circle" header-data-tooltip="クリックすると、サイトの使い方が表示されます"></i>
   </div>
   <% if current_user && current_user.boards_requests.present? %>
     <div class = "board_request_hader_box">


### PR DESCRIPTION
Typescriptで導入する予定だったが、CSSだけで実装できたのでCSSのみ使用
  -TOP画面タイトル横の？マークにカーソルを合わせると説明が表示される機能を追加
  -チャットルーム画面で、マイク、ビデオをブラウザで許可した時、パソコンによってセキュリティが強いと、ページの再読み込みが行われないため、デバイスが表示されない場合にページを再読み込みしてくださいという文章を追加